### PR TITLE
Fix parameter name for allowed MIME types in file storage

### DIFF
--- a/lib/core/files/infrastructure/file_storage_repository.dart
+++ b/lib/core/files/infrastructure/file_storage_repository.dart
@@ -63,7 +63,7 @@ class FileStorageRepository {
           return left(
             Failure.storage(
               message: 'formValidator.fileTypeNotAllowed'.tr(namedArgs: {
-                'extencions': allowedMimes.join(', '),
+                'extensions': allowedMimes.join(', '),
               }),
             ),
           );
@@ -126,7 +126,7 @@ class FileStorageRepository {
             return left(
               Failure.storage(
                 message: 'formValidator.fileTypeNotAllowed'.tr(namedArgs: {
-                  'extencions': allowedMimes.join(', '),
+                  'extensions': allowedMimes.join(', '),
                 }),
               ),
             );
@@ -194,7 +194,7 @@ class FileStorageRepository {
           return left(
             Failure.storage(
               message: 'formValidator.fileTypeNotAllowed'.tr(namedArgs: {
-                'extencions': allowedMimes.join(', '),
+                'extensions': allowedMimes.join(', '),
               }),
             ),
           );


### PR DESCRIPTION
## Summary
- fix variable name for `fileTypeNotAllowed` translation in FileStorageRepository

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684222ae3a488328abd81095bc778055