### PR TITLE
Add pet details screen with full pet form

### DIFF
--- a/lib/pets/presentation/screens/pet_details_screen.dart
+++ b/lib/pets/presentation/screens/pet_details_screen.dart
@@ -1,7 +1,29 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:petto/app/theme/app_theme_sizes.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:shimmer/shimmer.dart';
 import 'package:petto/core/files/application/app_file_view_model.dart';
+import 'package:petto/core/files/application/files_notifier.dart';
+import 'package:petto/core/files/application/files_state.dart' as fs;
+import 'package:petto/core/files/application/files_storage_path_provider.dart';
+import 'package:petto/core/files/application/files_firestore_path_provider.dart';
+import 'package:petto/core/files/constant/crop_options_constants.dart';
+import 'package:petto/core/files/presentation/widgets/single_file.dart';
+import 'package:petto/core/form/application/base_entity_state.dart';
+import 'package:petto/core/form/application/touched_provider.dart';
+import 'package:petto/core/presentation/widgets/flash.dart';
+import 'package:petto/pets/app/pet_notifier.dart';
+import 'package:petto/pets/domain/pet.dart';
+import 'package:petto/pets/domain/pet_breed.dart';
+import 'package:petto/pets/presentation/widgets/pet_form.dart';
+import 'package:petto/pets/shared/constant.dart';
+import 'package:petto/pets/shared/providers.dart';
 
-class PetDetailsScreen extends StatelessWidget {
+class PetDetailsScreen extends ConsumerStatefulWidget {
   const PetDetailsScreen({
     super.key,
     required this.id,
@@ -12,10 +34,248 @@ class PetDetailsScreen extends StatelessWidget {
   final List<AppFileViewModel> files;
 
   @override
+  ConsumerState<PetDetailsScreen> createState() => _PetDetailsScreenState();
+}
+
+class _PetDetailsScreenState extends ConsumerState<PetDetailsScreen> {
+  final String filesFolder = 'files';
+
+  String get family => petsModule;
+
+  bool get hasFilePending =>
+      ref.read(filesNotifierProvider(family).notifier).hasFilesPending;
+
+  String get collectionPath => ref.read(petCollectionPathProvider);
+
+  String? get storagePath => _buildStoragePath(widget.id);
+
+  String? get firestorePath => _buildFirestorePath(widget.id);
+
+  PetBreed? _selectedBreed;
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('PetDetailsScreen'),
+    ref.listen<BaseEntityState<Pet>>(
+      petNotifierProvider,
+      (previous, next) async {
+        if (next is FailureState<Pet>) {
+          showCustomFlash(
+            context,
+            next.failure.message ?? 'error.unexpectedError'.tr(),
+          );
+        }
+
+        if (next is Data<Pet>) {
+          if (widget.files.isNotEmpty) {
+            ref
+                .read(filesNotifierProvider(family).notifier)
+                .processFiles(files: widget.files);
+          }
+
+          if (hasFilePending) {
+            ref
+                .read(filesStoragePathProvider(family).notifier)
+                .set(_buildStoragePath(widget.id));
+            ref
+                .read(filesFirestorePathProvider(family).notifier)
+                .set(_buildFirestorePath(widget.id));
+            await ref
+                .read(filesNotifierProvider(family).notifier)
+                .processFiles();
+          }
+        }
+      },
+    );
+
+    ref.listen<fs.FilesState>(
+      filesNotifierProvider(family),
+      (previous, next) {
+        switch (next) {
+          case fs.Loading():
+            break;
+          case fs.Loaded(files: final files, status: final status):
+            if (status == fs.LoadedStatus.fromDatabase &&
+                files.isEmpty &&
+                widget.files.isNotEmpty) {
+              ref
+                  .read(filesNotifierProvider(family).notifier)
+                  .processFiles(files: widget.files);
+            }
+            if (status == fs.LoadedStatus.afterProcessing) {
+              if (hasFilePending) {
+                showCustomFlash(context, 'error.filesNotProcessed'.tr());
+                return;
+              }
+              _setTouchedState(hasFilePending);
+            }
+            break;
+        }
+      },
+    );
+
+    final formIsLoading =
+        ref.watch(petNotifierProvider.select((s) => s is Loading<Pet>));
+    final filesIsLoading =
+        ref.watch(filesNotifierProvider(family).select((s) => s is fs.Loading));
+    final loading = formIsLoading || filesIsLoading;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Edit pet'.tr()),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new_rounded),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppThemeSpacing.mediumW),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(height: AppThemeSpacing.extraSmallH),
+                SingleFile(
+                  family: family,
+                  storagePath: storagePath,
+                  firestorePath: firestorePath,
+                  cropOptions: circle300x300,
+                  onFileChanged: (_) => _setTouchedState(hasFilePending),
+                  showCancelAction: false,
+                  showDeleteAction: false,
+                  showRetryAction: false,
+                  isLoading: loading,
+                  unselectedFileWidget: (onImageTap) =>
+                      _PetAvatar(breed: _selectedBreed, onImageTap: onImageTap),
+                  borderRadius: BorderRadius.circular(AppThemeSpacing.extraLargeH),
+                  thumbnailHeight: AppThemeSpacing.ultraH,
+                  thumbnailWidth: AppThemeSpacing.ultraH,
+                ),
+                SizedBox(height: AppThemeSpacing.smallH),
+                PetForm(
+                  id: widget.id,
+                  setTouchedState: (touched) {
+                    _setTouchedState(touched || hasFilePending);
+                  },
+                  beforeSave: (entity) async {
+                    ref
+                        .read(filesNotifierProvider(family).notifier)
+                        .processFiles(hold: true);
+                  },
+                  onBreedChanged: (breed) {
+                    setState(() => _selectedBreed = breed);
+                  },
+                ),
+              ],
+            ),
+          ),
+          if (loading)
+            Container(
+              height: 1.sh,
+              width: 1.sw,
+              color: Theme.of(context)
+                  .colorScheme
+                  .surfaceContainerHighest
+                  .withAlpha((.5 * 255).toInt()),
+              child: const Center(child: CircularProgressIndicator()),
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _setTouchedState(bool touched) {
+    final notifier = ref.read(touchedProvider(petsModule).notifier);
+    touched ? notifier.touched() : notifier.untouched();
+  }
+
+  String _buildStoragePath(String id) => '$collectionPath/$id/$filesFolder';
+  String _buildFirestorePath(String id) => '$collectionPath/$id/$filesFolder';
+}
+
+class _PetAvatar extends StatelessWidget {
+  const _PetAvatar({
+    required this.breed,
+    required this.onImageTap,
+  });
+
+  final PetBreed? breed;
+  final VoidCallback onImageTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final double radius = AppThemeSpacing.extraLargeH;
+    final double avatarSize = radius * 2;
+
+    final String? networkUrl = breed?.defaultImageUrl;
+
+    final Widget imageWidget = networkUrl != null
+        ? CachedNetworkImage(
+            imageUrl: networkUrl,
+            fit: BoxFit.cover,
+            width: avatarSize,
+            height: avatarSize,
+            placeholder: (context, url) => Shimmer.fromColors(
+              baseColor: Theme.of(context).colorScheme.surface,
+              highlightColor: Colors.grey[100]!,
+              child: Container(
+                height: avatarSize,
+                width: avatarSize,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  shape: BoxShape.circle,
+                  boxShadow: [AppThemeShadow.small],
+                ),
+              ),
+            ),
+            errorWidget: (_, __, ___) =>
+                Icon(Icons.image_not_supported, size: avatarSize * .5),
+          )
+        : Icon(Icons.pets_rounded,
+            size: avatarSize * .5,
+            color: Theme.of(context).colorScheme.primaryContainer);
+
+    return SizedBox(
+      width: avatarSize,
+      height: avatarSize,
+      child: Stack(
+        children: [
+          Container(
+            width: avatarSize,
+            height: avatarSize,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              shape: BoxShape.circle,
+              boxShadow: [AppThemeShadow.small],
+            ),
+            child: ClipOval(child: imageWidget),
+          ),
+          Positioned(
+            bottom: 0,
+            right: 0,
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: onImageTap,
+                borderRadius: BorderRadius.circular(AppThemeSpacing.smallH),
+                child: Ink(
+                  padding: EdgeInsets.all(AppThemeSpacing.extraTinyH),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    shape: BoxShape.circle,
+                    boxShadow: [AppThemeShadow.small],
+                  ),
+                  child: Icon(
+                    Icons.camera_alt,
+                    size: AppThemeSpacing.smallH,
+                    color: Theme.of(context).colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pets/presentation/widgets/pet_form.dart
+++ b/lib/pets/presentation/widgets/pet_form.dart
@@ -1,0 +1,497 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:petto/app/theme/app_theme_sizes.dart';
+import 'package:petto/core/domain/failure.dart';
+import 'package:petto/core/files/application/app_file_view_model.dart';
+import 'package:petto/core/files/application/files_notifier.dart';
+import 'package:petto/core/form/application/base_entity_state.dart';
+import 'package:petto/core/form/application/form_state_interface.dart';
+import 'package:petto/core/form/application/id_provider.dart';
+import 'package:petto/core/form/application/touched_provider.dart';
+import 'package:petto/core/presentation/widgets/flash.dart';
+import 'package:petto/pets/app/pet_notifier.dart';
+import 'package:petto/pets/domain/pet.dart';
+import 'package:petto/pets/domain/pet_breed.dart';
+import 'package:petto/pets/domain/pet_sex.dart';
+import 'package:petto/pets/domain/pet_specie.dart';
+import 'package:petto/pets/domain/pet_vm.dart';
+import 'package:petto/pets/domain/food_type.dart';
+import 'package:petto/pets/domain/pet_size.dart';
+import 'package:petto/pets/shared/constant.dart';
+
+class PetForm extends StatefulHookConsumerWidget {
+  const PetForm({
+    super.key,
+    required this.id,
+    this.setTouchedState,
+    this.beforeSave,
+    this.onBreedChanged,
+  });
+
+  /// Unique identifier for the Pet.
+  final String id;
+
+  /// Sets the touched state from parent.
+  final void Function(bool touched)? setTouchedState;
+
+  /// Runs before saving.
+  final Future<void> Function(Pet entity)? beforeSave;
+
+  /// Notifies whenever the breed changes (including resets to null).
+  final Function(PetBreed? breed)? onBreedChanged;
+
+  @override
+  ConsumerState<PetForm> createState() => _PetFormState();
+}
+
+class _PetFormState extends ConsumerState<PetForm> implements FormStateInterface<Pet, PetVM> {
+  @override
+  final fk = GlobalKey<FormBuilderState>();
+
+  @override
+  bool loading = true;
+
+  @override
+  bool alreadyValidated = false;
+
+  @override
+  PetVM values = PetVM.empty();
+
+  PetSex? _selectedPetSex;
+  PetSpecie? _selectedSpecie;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () => ref.read(idProvider(petsModule).notifier).id = widget.id,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final autovalidateMode = alreadyValidated ? AutovalidateMode.onUserInteraction : AutovalidateMode.disabled;
+
+    ref.listen<BaseEntityState<Pet>>(
+      petNotifierProvider,
+      (previous, next) {
+        if (next is Data<Pet>) {
+          final entity = next.entity;
+          setState(() {
+            values = populate(entity);
+            if (loading) {
+              setTouchedState(false);
+              loading = false;
+              alreadyValidated = false;
+            }
+          });
+          return;
+        } else if (next is FailureState<Pet>) {
+          setState(() => loading = false);
+          showCustomFlash(
+            context,
+            next.failure.message ?? 'error.unexpectedError'.tr(),
+          );
+        }
+      },
+    );
+
+    final isTouched = ref.watch(touchedProvider(petsModule));
+
+    return FormBuilder(
+      key: fk,
+      onChanged: onChanged,
+      autovalidateMode: autovalidateMode,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: AppThemeSpacing.mediumW),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: AppThemeSpacing.extraSmallH,
+          children: [
+            // Hidden field to store the selected gender so it can be validated
+            FormBuilderField<PetSex>(
+              name: 'sex',
+              initialValue: _selectedPetSex,
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: 'validators.fieldRequired'.tr()),
+              ]),
+              builder: (field) => const SizedBox.shrink(),
+            ),
+            FormBuilderTextField(
+              name: 'name',
+              keyboardType: TextInputType.name,
+              decoration: InputDecoration(labelText: 'name'.tr()),
+              autovalidateMode: autovalidateMode,
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: 'validators.fieldRequired'.tr()),
+              ]),
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: FormBuilderDropdown<PetSpecie>(
+                    name: 'specie',
+                    autovalidateMode: autovalidateMode,
+                    decoration: InputDecoration(labelText: 'specie'.tr()),
+                    items: PetSpecie.values
+                        .map((specie) => DropdownMenuItem(
+                              value: specie,
+                              child: Text(specie.displayName),
+                            ))
+                        .toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedSpecie = value;
+                        // Reset breed whenever specie changes
+                        fk.currentState?.fields['breed']?.didChange(null);
+                        widget.onBreedChanged?.call(null);
+                      });
+                    },
+                    validator: FormBuilderValidators.compose([
+                      FormBuilderValidators.required(errorText: 'validators.fieldRequired'.tr()),
+                    ]),
+                  ),
+                ),
+                SizedBox(width: AppThemeSpacing.smallW),
+                Expanded(
+                  child: FormBuilderDropdown<PetBreed>(
+                    name: 'breed',
+                    autovalidateMode: autovalidateMode,
+                    decoration: InputDecoration(labelText: 'breed'.tr()),
+                    items: (_selectedSpecie == null
+                            ? <PetBreed>[]
+                            : PetBreed.values.where((b) => b.specie == _selectedSpecie).toList())
+                        .map((breed) => DropdownMenuItem(
+                              value: breed,
+                              child: Text(breed.displayName),
+                            ))
+                        .toList(),
+                    onChanged: widget.onBreedChanged,
+                    validator: FormBuilderValidators.compose([
+                      FormBuilderValidators.required(errorText: 'validators.fieldRequired'.tr()),
+                    ]),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: InkWell(
+                    onTap: () {
+                      setState(() => _selectedPetSex = PetSex.male);
+                      fk.currentState?.fields['sex']?.didChange(PetSex.male);
+                      onChanged();
+                    },
+                    borderRadius: BorderRadius.all(AppThemeRadius.medium),
+                    child: Ink(
+                      padding: EdgeInsets.all(AppThemeSpacing.extraTinyH),
+                      decoration: BoxDecoration(
+                        color: _selectedPetSex == PetSex.male ? colorScheme.primaryContainer : colorScheme.surface,
+                        borderRadius: BorderRadius.all(AppThemeRadius.medium),
+                        boxShadow: [AppThemeShadow.small],
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(PetSex.male.displayName),
+                          SizedBox(width: AppThemeSpacing.smallW),
+                          Icon(
+                            Icons.male,
+                            size: AppThemeSpacing.smallH,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(width: AppThemeSpacing.smallW),
+                Expanded(
+                  child: InkWell(
+                    onTap: () {
+                      setState(() => _selectedPetSex = PetSex.female);
+                      fk.currentState?.fields['sex']?.didChange(PetSex.female);
+                      onChanged();
+                    },
+                    borderRadius: BorderRadius.all(AppThemeRadius.medium),
+                    child: Ink(
+                      padding: EdgeInsets.all(AppThemeSpacing.extraTinyH),
+                      decoration: BoxDecoration(
+                        color: _selectedPetSex == PetSex.female ? colorScheme.primaryContainer : colorScheme.surface,
+                        borderRadius: BorderRadius.all(AppThemeRadius.medium),
+                        boxShadow: [AppThemeShadow.small],
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(PetSex.female.displayName),
+                          SizedBox(width: AppThemeSpacing.smallW),
+                          Icon(
+                            Icons.female,
+                            size: AppThemeSpacing.smallH,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            FormBuilderDateTimePicker(
+              name: 'birthDate',
+              locale: context.locale,
+              keyboardType: TextInputType.datetime,
+              format: DateFormat.yMd(context.locale.languageCode),
+              inputType: InputType.date,
+              firstDate: DateTime(1900),
+              lastDate: DateTime.now(),
+              decoration: InputDecoration(labelText: 'birthDate'.tr()),
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: 'validators.fieldRequired'.tr()),
+                FormBuilderValidators.dateTime(errorText: 'validators.invalidDate'),
+              ]),
+            ),
+            FormBuilderTextField(
+              name: "color",
+              keyboardType: TextInputType.text,
+              decoration: InputDecoration(labelText: "color".tr()),
+              autovalidateMode: autovalidateMode,
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: "validators.fieldRequired".tr()),
+              ]),
+            ),
+            FormBuilderTextField(
+              name: "weight",
+              keyboardType: TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(labelText: "weight".tr()),
+              autovalidateMode: autovalidateMode,
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: "validators.fieldRequired".tr()),
+                FormBuilderValidators.numeric(),
+              ]),
+            ),
+            FormBuilderDropdown<PetSize>(
+              name: "size",
+              autovalidateMode: autovalidateMode,
+              decoration: InputDecoration(labelText: "size".tr()),
+              items: PetSize.values
+                  .map((s) => DropdownMenuItem(value: s, child: Text(s.name)))
+                  .toList(),
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: "validators.fieldRequired".tr()),
+              ]),
+            ),
+            FormBuilderDropdown<FoodType>(
+              name: "foodType",
+              autovalidateMode: autovalidateMode,
+              decoration: InputDecoration(labelText: "foodType".tr()),
+              items: FoodType.values
+                  .map((f) => DropdownMenuItem(value: f, child: Text(f.displayName)))
+                  .toList(),
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: "validators.fieldRequired".tr()),
+              ]),
+            ),
+            FormBuilderTextField(
+              name: "microchipNumber",
+              keyboardType: TextInputType.text,
+              decoration: InputDecoration(labelText: "microchipNumber".tr()),
+              autovalidateMode: autovalidateMode,
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(errorText: "validators.fieldRequired".tr()),
+              ]),
+            ),
+            ElevatedButton(
+              onPressed: (loading || !isTouched) ? null : save,
+              child: Text('save'.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  PetVM extract() {
+    // Current breed value
+    final breed = getField<PetBreed>('breed') ?? values.breed;
+
+    // Files handled by the picker/uploader for this form
+    final files = ref.read(filesNotifierProvider(petsModule)).files;
+
+    // Helper booleans
+    final bool hasUploads = files.any((f) => f.status == AppFileStatus.upload);
+    final bool hasActiveFiles = files.any((f) => f.status != AppFileStatus.delete && f.status != AppFileStatus.deleted);
+    final bool allDeleted = files.isNotEmpty && !hasActiveFiles; // user removed every image
+
+    String? photoUrl;
+
+    if (values.id == '0') {
+      photoUrl = hasUploads ? null : breed.defaultImageUrl;
+    } else {
+      if (hasUploads) {
+        // User picked a new image → let backend keep uploaded file.
+        photoUrl = null;
+      } else if (allDeleted) {
+        // Deleted previous photo and did not upload a new one → fallback.
+        photoUrl = breed.defaultImageUrl;
+      } else {
+        // No changes on files → keep existing url.
+        photoUrl = values.photoUrl;
+      }
+    }
+
+    return PetVM(
+      id: values.id,
+      name: getField('name') ?? values.name,
+      specie: getField('specie') ?? values.specie,
+      breed: breed,
+      sex: getField('sex') ?? values.sex,
+      birthDate: getField('birthDate') ?? values.birthDate,
+      color: getField('color') ?? values.color,
+      weight: getField('weight') ?? values.weight,
+      foodType: getField('foodType') ?? values.foodType,
+      microchipNumber: getField('microchipNumber') ?? values.microchipNumber,
+      size: getField('size') ?? values.size,
+      photoUrl: photoUrl,
+    );
+  }
+
+  @override
+  PetVM populate(Pet entity) {
+    final vm = PetVM.fromEntity(entity);
+    final isNewEntity = values.id == '0';
+
+    if (loading || vm.name == getField('name')) {
+      setField('name', vm.name);
+    }
+
+    if (!isNewEntity && (loading || vm.specie == getField('specie'))) {
+      setField('specie', vm.specie);
+    }
+
+    if (!isNewEntity && (loading || vm.breed == getField('breed'))) {
+      setField('breed', vm.breed);
+      widget.onBreedChanged?.call(vm.breed);
+    }
+
+    if (loading || vm.sex == getField('sex')) {
+      setField('sex', vm.sex);
+    }
+
+    if (!isNewEntity) {
+      _selectedPetSex = vm.sex;
+    }
+
+    if (!isNewEntity && (loading || vm.birthDate == getField('birthDate'))) {
+      setField('birthDate', vm.birthDate);
+    }
+
+    if (loading || vm.color == getField('color')) {
+      setField('color', vm.color);
+    }
+
+    if (loading || vm.weight == getField('weight')) {
+      setField('weight', vm.weight);
+    }
+
+    if (loading || vm.foodType == getField('foodType')) {
+      setField('foodType', vm.foodType);
+    }
+
+    if (loading || vm.microchipNumber == getField('microchipNumber')) {
+      setField('microchipNumber', vm.microchipNumber);
+    }
+
+    if (loading || vm.size == getField('size')) {
+      setField('size', vm.size);
+    }
+
+    return vm;
+  }
+
+  @override
+  Future<void> save({bool validateForm = true}) async {
+    final entity = ref.read(petNotifierProvider).entity;
+    if (entity == null) return;
+
+    if (validateForm) {
+      if (!validate(markAsLoading: true)) return;
+    }
+    FocusScope.of(context).unfocus();
+
+    final formData = extract();
+    final upsertData = formData.toEntity(entity);
+
+    if (widget.beforeSave != null) {
+      await widget.beforeSave!(upsertData);
+    }
+    await ref.read(petNotifierProvider.notifier).save(upsertData);
+  }
+
+  @override
+  void checkTouched() {
+    final currentValue = extract();
+    final hasChanges = values != currentValue;
+    if (ref.read(touchedProvider(petsModule)) != hasChanges) {
+      setTouchedState(hasChanges);
+    }
+  }
+
+  @override
+  void setTouchedState(bool touched) {
+    if (widget.setTouchedState != null) {
+      widget.setTouchedState!(touched);
+      return;
+    }
+    if (touched) {
+      ref.read(touchedProvider(petsModule).notifier).touched();
+    } else {
+      ref.read(touchedProvider(petsModule).notifier).untouched();
+    }
+  }
+
+  @override
+  void onChanged() {
+    if (!loading && fk.currentState?.isTouched == true) {
+      checkTouched();
+    }
+  }
+
+  @override
+  bool validate({bool markAsLoading = false}) {
+    final isValid = fk.currentState!.validate();
+
+    if (!isValid) {
+      ref.read(petNotifierProvider.notifier).fail(
+            Failure.validation(
+              message: fk.currentState!.errors.values.first.toString(),
+            ),
+            recordError: false,
+          );
+    }
+
+    setState(() {
+      if (markAsLoading && isValid) loading = true;
+      if (!alreadyValidated) alreadyValidated = true;
+    });
+
+    return isValid;
+  }
+
+  @override
+  FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>? fieldRef(String fieldName) =>
+      fk.currentState?.fields[fieldName];
+
+  @override
+  T? getField<T>(String fieldName) => fieldRef(fieldName)?.value as T?;
+
+  @override
+  void setField(String fieldName, dynamic value) {
+    fieldRef(fieldName)?.didChange(value);
+  }
+}


### PR DESCRIPTION
## Summary
- create `PetForm` with complete set of fields for editing a pet
- implement `PetDetailsScreen` using `PetForm` and `SingleFile` widget

## Testing
- `dart format -o none --set-exit-if-changed lib/pets/presentation/screens/pet_details_screen.dart lib/pets/presentation/widgets/pet_form.dart` *(fails: dart not found)*
- `flutter analyze` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684223f5ad008328aac019c2e4445c3e