### PR TITLE
Add pet profile screen

### DIFF
--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -205,5 +205,7 @@
   "deleteAccount": "Eliminar cuenta",
   "reminderListTitle": "Lista de recordatorios",
   "reminderDetails": "Detalles del recordatorio",
-  "registerPet": "Registra tu mascota"
+  "registerPet": "Registra tu mascota",
+  "petProfile": "Perfil de mascota",
+  "sharePet": "Compartir mascota"
 }

--- a/lib/home/presentation/widgets/profile_view.dart
+++ b/lib/home/presentation/widgets/profile_view.dart
@@ -138,7 +138,9 @@ class _PetsCarousel extends HookConsumerWidget {
         onTap: () => PetDetailsRoute(petId: '0').push(context),
       ),
       itemBuilder: (pet) => _PetAvatarCard(
-          pet: pet, avatarDiameter: avatarDiameter, onTap: () => PetDetailsRoute(petId: pet.id).push(context)),
+          pet: pet,
+          avatarDiameter: avatarDiameter,
+          onTap: () => PetProfileRoute(petId: pet.id).push(context)),
     );
   }
 }

--- a/lib/pets/presentation/screens/pet_profile_screen.dart
+++ b/lib/pets/presentation/screens/pet_profile_screen.dart
@@ -1,0 +1,106 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:petto/app/theme/app_theme_sizes.dart';
+import 'package:petto/pets/router.dart';
+
+class PetProfileScreen extends StatelessWidget {
+  const PetProfileScreen({
+    super.key,
+    required this.petId,
+  });
+
+  final String petId;
+
+  @override
+  Widget build(BuildContext context) {
+    final options = [
+      _PetProfileOption(
+        title: 'editPet',
+        icon: Icons.edit,
+        onTap: () => PetDetailsRoute(petId: petId).push(context),
+      ),
+      _PetProfileOption(
+        title: 'sharePet',
+        icon: Icons.share,
+        onTap: () => PetShareRoute(petId: petId).push(context),
+      ),
+    ];
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            title: Text('petProfile'.tr()),
+            centerTitle: true,
+            floating: true,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded),
+              onPressed: () => context.pop(),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: AppThemeSpacing.mediumW),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: options
+                    .map((o) => Padding(
+                          padding: EdgeInsets.only(
+                              bottom: AppThemeSpacing.extraSmallH),
+                          child: _OptionTile(option: o),
+                        ))
+                    .toList(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OptionTile extends StatelessWidget {
+  const _OptionTile({required this.option});
+
+  final _PetProfileOption option;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: option.onTap,
+      borderRadius: const BorderRadius.all(AppThemeRadius.medium),
+      child: Ink(
+        padding: EdgeInsets.all(AppThemeSpacing.tinyH),
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(AppThemeRadius.medium),
+          color: colorScheme.surface,
+          boxShadow: [AppThemeShadow.small],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Icon(option.icon),
+            Text(option.title.tr(), style: textTheme.titleMedium),
+            Icon(Icons.arrow_forward_ios_rounded, color: colorScheme.primary),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PetProfileOption {
+  const _PetProfileOption({
+    required this.title,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String title;
+  final IconData icon;
+  final VoidCallback onTap;
+}

--- a/lib/pets/presentation/screens/pet_share_screen.dart
+++ b/lib/pets/presentation/screens/pet_share_screen.dart
@@ -1,0 +1,38 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:petto/app/theme/app_theme_sizes.dart';
+
+class PetShareScreen extends StatelessWidget {
+  const PetShareScreen({
+    super.key,
+    required this.petId,
+  });
+
+  final String petId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            title: Text('sharePet'.tr()),
+            centerTitle: true,
+            floating: true,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded),
+              onPressed: () => context.pop(),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: AppThemeSpacing.mediumW),
+              child: const SizedBox.shrink(),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pets/router.dart
+++ b/lib/pets/router.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 // Screens for the pets feature (replace with real imports).
 import 'package:petto/pets/presentation/screens/create_or_import_pet_screen.dart';
 import 'package:petto/pets/presentation/screens/pet_details_screen.dart';
+import 'package:petto/pets/presentation/screens/pet_profile_screen.dart';
+import 'package:petto/pets/presentation/screens/pet_share_screen.dart';
 import 'package:petto/core/files/application/app_file_view_model.dart';
 
 part 'router.g.dart';
@@ -14,8 +16,11 @@ part 'router.g.dart';
   routes: <TypedGoRoute<GoRouteData>>[
     // Step 1: choose how to add the pet
     TypedGoRoute<CreateOrImportPetRoute>(path: 'create-or-import'),
+    // Pet profile view
+    TypedGoRoute<PetProfileRoute>(path: 'profile/:petId'),
+    // Share pet view
+    TypedGoRoute<PetShareRoute>(path: 'share/:petId'),
     // Detail or registration view for a specific pet
-    
     TypedGoRoute<PetDetailsRoute>(path: ':petId'),
   ],
 )
@@ -51,5 +56,28 @@ class PetDetailsRoute extends GoRouteData {
   final bool basic;
 
   @override
-  Widget build(BuildContext context, GoRouterState state) => PetDetailsScreen(id: petId, files: $extra, basic: basic);
+  Widget build(BuildContext context, GoRouterState state) =>
+      PetDetailsScreen(id: petId, files: $extra, basic: basic);
+}
+
+/// Screen showing pet profile options.
+class PetProfileRoute extends GoRouteData {
+  const PetProfileRoute({required this.petId});
+
+  final String petId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      PetProfileScreen(petId: petId);
+}
+
+/// Screen to share pet – currently empty.
+class PetShareRoute extends GoRouteData {
+  const PetShareRoute({required this.petId});
+
+  final String petId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      PetShareScreen(petId: petId);
 }

--- a/lib/pets/router.g.dart
+++ b/lib/pets/router.g.dart
@@ -19,6 +19,14 @@ RouteBase get $petsRoute => GoRouteData.$route(
           factory: $CreateOrImportPetRouteExtension._fromState,
         ),
         GoRouteData.$route(
+          path: 'profile/:petId',
+          factory: $PetProfileRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
+          path: 'share/:petId',
+          factory: $PetShareRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
           path: ':petId',
           factory: $PetDetailsRouteExtension._fromState,
         ),
@@ -48,6 +56,44 @@ extension $CreateOrImportPetRouteExtension on CreateOrImportPetRoute {
 
   String get location => GoRouteData.$location(
         '/pets/create-or-import',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $PetProfileRouteExtension on PetProfileRoute {
+  static PetProfileRoute _fromState(GoRouterState state) => PetProfileRoute(
+        petId: state.pathParameters['petId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/pets/profile/${Uri.encodeComponent(petId)}',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $PetShareRouteExtension on PetShareRoute {
+  static PetShareRoute _fromState(GoRouterState state) => PetShareRoute(
+        petId: state.pathParameters['petId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/pets/share/${Uri.encodeComponent(petId)}',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- add pet profile and share screens
- update navigation to use pet profile screen
- wire pet profile and share routes
- add translations for pet profile and share pet

## Testing
- `flutter` not installed; no tests run

------
https://chatgpt.com/codex/tasks/task_e_684633a4401c8328a68a91cdd783a5dc