### PR TITLE
Add infrastructure for pet share module

### DIFF
--- a/lib/pet_share/domain/pet_share_invite.dart
+++ b/lib/pet_share/domain/pet_share_invite.dart
@@ -37,4 +37,15 @@ sealed class PetShareInvite with _$PetShareInvite implements BaseEntity {
     /// Useful for analytics or troubleshooting.
     DateTime? redeemedAt,
   }) = _PetShareInvite;
+
+  /// Factory helper for empty placeholders or tests.
+  factory PetShareInvite.empty() => PetShareInvite(
+        id: '',
+        petId: '',
+        defaultRole: PetShareRole.viewer,
+        invitedBy: '',
+        expiresAt: DateTime.now(),
+        redeemedBy: null,
+        redeemedAt: null,
+      );
 }

--- a/lib/pet_share/infrastructure/pet_share_dto.dart
+++ b/lib/pet_share/infrastructure/pet_share_dto.dart
@@ -1,0 +1,90 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:petto/core/domain/json_converter/timestamp_converter.dart';
+import 'package:petto/core/infrastructure/base_dto.dart';
+import 'package:petto/pet_share/domain/pet_share.dart';
+import 'package:petto/pet_share/domain/pet_share_role.dart';
+import 'package:petto/users/domain/user.dart';
+
+class PetShareDTO implements BaseDTO<PetShare> {
+  PetShareDTO({
+    required this.id,
+    required this.petId,
+    required this.userId,
+    required this.role,
+    required this.expiresAt,
+    required this.createdAt,
+    required this.invitedBy,
+  });
+
+  factory PetShareDTO.fromJson(Map<String, dynamic> json, String id) {
+    return PetShareDTO(
+      id: id,
+      petId: json['petId'] as String,
+      userId: json['userId'] as String,
+      role: PetShareRole.values.firstWhere((e) => e.name == json['role']),
+      expiresAt: json['expiresAt'] != null
+          ? const TimestampConverter().fromJson(json['expiresAt'] as Timestamp)
+          : null,
+      createdAt:
+          const TimestampConverter().fromJson(json['createdAt'] as Timestamp),
+      invitedBy: json['invitedBy'] as String,
+    );
+  }
+
+  factory PetShareDTO.fromDocumentSnapshot(DocumentSnapshot doc) {
+    return PetShareDTO.fromJson(doc.data()! as Map<String, dynamic>, doc.id);
+  }
+
+  factory PetShareDTO.fromDomain(PetShare share) {
+    return PetShareDTO(
+      id: share.id,
+      petId: share.petId,
+      userId: share.userId,
+      role: share.role,
+      expiresAt: share.expiresAt,
+      createdAt: share.createdAt,
+      invitedBy: share.invitedBy,
+    );
+  }
+
+  final String id;
+  final String petId;
+  final String userId;
+  final PetShareRole role;
+  final DateTime? expiresAt;
+  final DateTime createdAt;
+  final String invitedBy;
+
+  @override
+  Map<String, dynamic> toDocument() {
+    return {
+      'petId': petId,
+      'userId': userId,
+      'role': role.name,
+      'expiresAt': expiresAt != null
+          ? const TimestampConverter().toJson(expiresAt!)
+          : null,
+      'createdAt': const TimestampConverter().toJson(createdAt),
+      'invitedBy': invitedBy,
+    }..removeWhere((key, value) => value == null);
+  }
+
+  @override
+  Map<String, dynamic> toCreateDocument(User user) => toDocument();
+
+  @override
+  Map<String, dynamic> toUpdateDocument(User user) => toDocument();
+
+  @override
+  PetShare toDomain() {
+    return PetShare(
+      id: id,
+      petId: petId,
+      userId: userId,
+      role: role,
+      expiresAt: expiresAt,
+      createdAt: createdAt,
+      invitedBy: invitedBy,
+    );
+  }
+}

--- a/lib/pet_share/infrastructure/pet_share_invite_dto.dart
+++ b/lib/pet_share/infrastructure/pet_share_invite_dto.dart
@@ -1,0 +1,91 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:petto/core/domain/json_converter/timestamp_converter.dart';
+import 'package:petto/core/infrastructure/base_dto.dart';
+import 'package:petto/pet_share/domain/pet_share_invite.dart';
+import 'package:petto/pet_share/domain/pet_share_role.dart';
+import 'package:petto/users/domain/user.dart';
+
+class PetShareInviteDTO implements BaseDTO<PetShareInvite> {
+  PetShareInviteDTO({
+    required this.id,
+    required this.petId,
+    required this.defaultRole,
+    required this.invitedBy,
+    required this.expiresAt,
+    this.redeemedBy,
+    this.redeemedAt,
+  });
+
+  factory PetShareInviteDTO.fromJson(Map<String, dynamic> json, String id) {
+    return PetShareInviteDTO(
+      id: id,
+      petId: json['petId'] as String,
+      defaultRole:
+          PetShareRole.values.firstWhere((e) => e.name == json['defaultRole']),
+      invitedBy: json['invitedBy'] as String,
+      expiresAt:
+          const TimestampConverter().fromJson(json['expiresAt'] as Timestamp),
+      redeemedBy: json['redeemedBy'] as String?,
+      redeemedAt: json['redeemedAt'] != null
+          ? const TimestampConverter().fromJson(json['redeemedAt'] as Timestamp)
+          : null,
+    );
+  }
+
+  factory PetShareInviteDTO.fromDocumentSnapshot(DocumentSnapshot doc) {
+    return PetShareInviteDTO.fromJson(doc.data()! as Map<String, dynamic>, doc.id);
+  }
+
+  factory PetShareInviteDTO.fromDomain(PetShareInvite invite) {
+    return PetShareInviteDTO(
+      id: invite.id,
+      petId: invite.petId,
+      defaultRole: invite.defaultRole,
+      invitedBy: invite.invitedBy,
+      expiresAt: invite.expiresAt,
+      redeemedBy: invite.redeemedBy,
+      redeemedAt: invite.redeemedAt,
+    );
+  }
+
+  final String id;
+  final String petId;
+  final PetShareRole defaultRole;
+  final String invitedBy;
+  final DateTime expiresAt;
+  final String? redeemedBy;
+  final DateTime? redeemedAt;
+
+  @override
+  Map<String, dynamic> toDocument() {
+    return {
+      'petId': petId,
+      'defaultRole': defaultRole.name,
+      'invitedBy': invitedBy,
+      'expiresAt': const TimestampConverter().toJson(expiresAt),
+      'redeemedBy': redeemedBy,
+      'redeemedAt': redeemedAt != null
+          ? const TimestampConverter().toJson(redeemedAt!)
+          : null,
+    }..removeWhere((key, value) => value == null);
+  }
+
+  @override
+  Map<String, dynamic> toCreateDocument(User user) => toDocument();
+
+  @override
+  Map<String, dynamic> toUpdateDocument(User user) => toDocument();
+
+  @override
+  PetShareInvite toDomain() {
+    return PetShareInvite(
+      id: id,
+      petId: petId,
+      defaultRole: defaultRole,
+      invitedBy: invitedBy,
+      expiresAt: expiresAt,
+      redeemedBy: redeemedBy,
+      redeemedAt: redeemedAt,
+    );
+  }
+}

--- a/lib/pet_share/shared/constant.dart
+++ b/lib/pet_share/shared/constant.dart
@@ -1,0 +1,2 @@
+/// Constant with module name. Used as [family] for 'FamilyProviders' of Riverpod.
+const petShareModule = 'petShare';

--- a/lib/pet_share/shared/providers.dart
+++ b/lib/pet_share/shared/providers.dart
@@ -1,0 +1,98 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:petto/auth/shared/providers.dart';
+import 'package:petto/core/infrastructure/base_firestore_repository.dart';
+import 'package:petto/core/list/application/firestore_query_helper.dart';
+import 'package:petto/core/list/application/query_clauses_provider.dart';
+import 'package:petto/core/list/application/search_notifier.dart';
+import 'package:petto/core/shared/providers.dart';
+import 'package:petto/pet_share/domain/pet_share.dart';
+import 'package:petto/pet_share/domain/pet_share_invite.dart';
+import 'package:petto/pet_share/infrastructure/pet_share_dto.dart';
+import 'package:petto/pet_share/infrastructure/pet_share_invite_dto.dart';
+
+/// Firestore collection path for pet shares.
+final petShareCollectionPathProvider =
+    Provider<String>((ref) => 'petShares');
+
+/// Repository provider for [PetShare].
+final petShareFirestoreRepositoryProvider =
+    Provider<BaseFirestoreRepository<PetShare>>((ref) {
+  return BaseFirestoreRepository<PetShare>(
+    collectionPath: ref.watch(petShareCollectionPathProvider),
+    firestore: ref.watch(firestoreProvider),
+    user: ref.watch(userProvider).value!,
+    emptyEntity: PetShare.empty(),
+    fromDomain: (e) => PetShareDTO.fromDomain(e),
+    fromDocumentSnapshot: (doc) => PetShareDTO.fromDocumentSnapshot(doc),
+  );
+});
+
+/// Parameters for [petSharesQueryProvider].
+class PetSharesQueryParams {
+  const PetSharesQueryParams({this.family, this.clauses = const []});
+  final String? family;
+  final List<QueryClause> clauses;
+}
+
+/// Query provider for pet shares.
+final petSharesQueryProvider = AutoDisposeProvider.family<Query<PetShare>,
+    PetSharesQueryParams>((ref, params) {
+  final firestore = ref.watch(firestoreProvider);
+  final collectionPath = ref.watch(petShareCollectionPathProvider);
+
+  final queryHelper = FirestoreQueryHelper<PetShare>(
+    ref: firestore.collection(collectionPath),
+    fromDomain: (e) => PetShareDTO.fromDomain(e),
+    fromDocumentSnapshot: (doc) => PetShareDTO.fromDocumentSnapshot(doc),
+    clauses: [...params.clauses, ...ref.watch(queryClausesProvider(params.family))],
+    stringAndField:
+        params.family != null ? ref.watch(searchNotifierProvider(params.family)) : null,
+  );
+
+  return queryHelper.query();
+});
+
+/// Firestore collection path for pet share invites.
+final petShareInviteCollectionPathProvider =
+    Provider<String>((ref) => 'petShareInvites');
+
+/// Repository provider for [PetShareInvite].
+final petShareInviteFirestoreRepositoryProvider =
+    Provider<BaseFirestoreRepository<PetShareInvite>>((ref) {
+  return BaseFirestoreRepository<PetShareInvite>(
+    collectionPath: ref.watch(petShareInviteCollectionPathProvider),
+    firestore: ref.watch(firestoreProvider),
+    user: ref.watch(userProvider).value!,
+    emptyEntity: PetShareInvite.empty(),
+    fromDomain: (e) => PetShareInviteDTO.fromDomain(e),
+    fromDocumentSnapshot: (doc) =>
+        PetShareInviteDTO.fromDocumentSnapshot(doc),
+  );
+});
+
+/// Parameters for [petShareInvitesQueryProvider].
+class PetShareInvitesQueryParams {
+  const PetShareInvitesQueryParams({this.family, this.clauses = const []});
+  final String? family;
+  final List<QueryClause> clauses;
+}
+
+/// Query provider for pet share invites.
+final petShareInvitesQueryProvider = AutoDisposeProvider.family<
+    Query<PetShareInvite>, PetShareInvitesQueryParams>((ref, params) {
+  final firestore = ref.watch(firestoreProvider);
+  final collectionPath = ref.watch(petShareInviteCollectionPathProvider);
+
+  final queryHelper = FirestoreQueryHelper<PetShareInvite>(
+    ref: firestore.collection(collectionPath),
+    fromDomain: (e) => PetShareInviteDTO.fromDomain(e),
+    fromDocumentSnapshot: (doc) =>
+        PetShareInviteDTO.fromDocumentSnapshot(doc),
+    clauses: [...params.clauses, ...ref.watch(queryClausesProvider(params.family))],
+    stringAndField:
+        params.family != null ? ref.watch(searchNotifierProvider(params.family)) : null,
+  );
+
+  return queryHelper.query();
+});


### PR DESCRIPTION
## Summary
- implement DTOs for `pet_share`
- create shared providers for pet share
- add `empty()` factory to `PetShareInvite`

## Testing
- `dart` and `flutter` commands unavailable in environment


------
https://chatgpt.com/codex/tasks/task_e_68463a3c33988328b424da6f03af3c7b