### PR TITLE
Refactor pet share invite module

### DIFF
--- a/lib/pet_share/infrastructure/pet_share_invite_dto.dart
+++ b/lib/pet_share/infrastructure/pet_share_invite_dto.dart
@@ -1,41 +1,37 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:petto/core/domain/json_converter/timestamp_converter.dart';
 import 'package:petto/core/infrastructure/base_dto.dart';
 import 'package:petto/pet_share/domain/pet_share_invite.dart';
 import 'package:petto/pet_share/domain/pet_share_role.dart';
 import 'package:petto/users/domain/user.dart';
 
-class PetShareInviteDTO implements BaseDTO<PetShareInvite> {
-  PetShareInviteDTO({
-    required this.id,
-    required this.petId,
-    required this.defaultRole,
-    required this.invitedBy,
-    required this.expiresAt,
-    this.redeemedBy,
-    this.redeemedAt,
-  });
+part 'pet_share_invite_dto.freezed.dart';
+part 'pet_share_invite_dto.g.dart';
 
-  factory PetShareInviteDTO.fromJson(Map<String, dynamic> json, String id) {
-    return PetShareInviteDTO(
-      id: id,
-      petId: json['petId'] as String,
-      defaultRole:
-          PetShareRole.values.firstWhere((e) => e.name == json['defaultRole']),
-      invitedBy: json['invitedBy'] as String,
-      expiresAt:
-          const TimestampConverter().fromJson(json['expiresAt'] as Timestamp),
-      redeemedBy: json['redeemedBy'] as String?,
-      redeemedAt: json['redeemedAt'] != null
-          ? const TimestampConverter().fromJson(json['redeemedAt'] as Timestamp)
-          : null,
-    );
-  }
+@freezed
+sealed class PetShareInviteDTO
+    with _$PetShareInviteDTO
+    implements BaseDTO<PetShareInvite> {
+  const PetShareInviteDTO._();
 
+  const factory PetShareInviteDTO({
+    @Default('') String id,
+    required String petId,
+    required PetShareRole defaultRole,
+    required String invitedBy,
+    @TimestampConverter() required DateTime expiresAt,
+    String? redeemedBy,
+    @TimestampConverter() DateTime? redeemedAt,
+  }) = _PetShareInviteDTO;
+
+  @Implements<FromDocumentSnapshotFactory>()
   factory PetShareInviteDTO.fromDocumentSnapshot(DocumentSnapshot doc) {
-    return PetShareInviteDTO.fromJson(doc.data()! as Map<String, dynamic>, doc.id);
+    final data = doc.data()! as Map<String, dynamic>;
+    return PetShareInviteDTO.fromJson(data).copyWith(id: doc.id);
   }
 
+  @Implements<FromDomainFactory>()
   factory PetShareInviteDTO.fromDomain(PetShareInvite invite) {
     return PetShareInviteDTO(
       id: invite.id,
@@ -48,27 +44,12 @@ class PetShareInviteDTO implements BaseDTO<PetShareInvite> {
     );
   }
 
-  final String id;
-  final String petId;
-  final PetShareRole defaultRole;
-  final String invitedBy;
-  final DateTime expiresAt;
-  final String? redeemedBy;
-  final DateTime? redeemedAt;
+  @Implements<FromJsonFactory>()
+  factory PetShareInviteDTO.fromJson(Map<String, dynamic> json) =>
+      _$PetShareInviteDTOFromJson(json);
 
   @override
-  Map<String, dynamic> toDocument() {
-    return {
-      'petId': petId,
-      'defaultRole': defaultRole.name,
-      'invitedBy': invitedBy,
-      'expiresAt': const TimestampConverter().toJson(expiresAt),
-      'redeemedBy': redeemedBy,
-      'redeemedAt': redeemedAt != null
-          ? const TimestampConverter().toJson(redeemedAt!)
-          : null,
-    }..removeWhere((key, value) => value == null);
-  }
+  Map<String, dynamic> toDocument() => toJson()..remove('id');
 
   @override
   Map<String, dynamic> toCreateDocument(User user) => toDocument();

--- a/lib/pet_share/shared/providers.dart
+++ b/lib/pet_share/shared/providers.dart
@@ -10,34 +10,33 @@ import 'package:petto/pet_share/domain/pet_share.dart';
 import 'package:petto/pet_share/domain/pet_share_invite.dart';
 import 'package:petto/pet_share/infrastructure/pet_share_dto.dart';
 import 'package:petto/pet_share/infrastructure/pet_share_invite_dto.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'providers.g.dart';
 
 /// Firestore collection path for pet shares.
-final petShareCollectionPathProvider =
-    Provider<String>((ref) => 'petShares');
+@riverpod
+String petShareCollectionPath(Ref ref) => 'petShares';
 
 /// Repository provider for [PetShare].
-final petShareFirestoreRepositoryProvider =
-    Provider<BaseFirestoreRepository<PetShare>>((ref) {
-  return BaseFirestoreRepository<PetShare>(
-    collectionPath: ref.watch(petShareCollectionPathProvider),
-    firestore: ref.watch(firestoreProvider),
-    user: ref.watch(userProvider).value!,
-    emptyEntity: PetShare.empty(),
-    fromDomain: (e) => PetShareDTO.fromDomain(e),
-    fromDocumentSnapshot: (doc) => PetShareDTO.fromDocumentSnapshot(doc),
-  );
-});
-
-/// Parameters for [petSharesQueryProvider].
-class PetSharesQueryParams {
-  const PetSharesQueryParams({this.family, this.clauses = const []});
-  final String? family;
-  final List<QueryClause> clauses;
-}
+@riverpod
+BaseFirestoreRepository<PetShare> petShareFirestoreRepository(Ref ref) =>
+    BaseFirestoreRepository<PetShare>(
+      collectionPath: ref.watch(petShareCollectionPathProvider),
+      firestore: ref.watch(firestoreProvider),
+      user: ref.watch(userProvider).value!,
+      emptyEntity: PetShare.empty(),
+      fromDomain: (e) => PetShareDTO.fromDomain(e),
+      fromDocumentSnapshot: (doc) => PetShareDTO.fromDocumentSnapshot(doc),
+    );
 
 /// Query provider for pet shares.
-final petSharesQueryProvider = AutoDisposeProvider.family<Query<PetShare>,
-    PetSharesQueryParams>((ref, params) {
+@riverpod
+Query<PetShare> petSharesQuery(
+  Ref ref, {
+  String? family,
+  List<QueryClause> clauses = const [],
+}) {
   final firestore = ref.watch(firestoreProvider);
   final collectionPath = ref.watch(petShareCollectionPathProvider);
 
@@ -45,42 +44,39 @@ final petSharesQueryProvider = AutoDisposeProvider.family<Query<PetShare>,
     ref: firestore.collection(collectionPath),
     fromDomain: (e) => PetShareDTO.fromDomain(e),
     fromDocumentSnapshot: (doc) => PetShareDTO.fromDocumentSnapshot(doc),
-    clauses: [...params.clauses, ...ref.watch(queryClausesProvider(params.family))],
+    clauses: [...clauses, ...ref.watch(queryClausesProvider(family))],
     stringAndField:
-        params.family != null ? ref.watch(searchNotifierProvider(params.family)) : null,
+        family != null ? ref.watch(searchNotifierProvider(family)) : null,
   );
 
   return queryHelper.query();
-});
-
-/// Firestore collection path for pet share invites.
-final petShareInviteCollectionPathProvider =
-    Provider<String>((ref) => 'petShareInvites');
-
-/// Repository provider for [PetShareInvite].
-final petShareInviteFirestoreRepositoryProvider =
-    Provider<BaseFirestoreRepository<PetShareInvite>>((ref) {
-  return BaseFirestoreRepository<PetShareInvite>(
-    collectionPath: ref.watch(petShareInviteCollectionPathProvider),
-    firestore: ref.watch(firestoreProvider),
-    user: ref.watch(userProvider).value!,
-    emptyEntity: PetShareInvite.empty(),
-    fromDomain: (e) => PetShareInviteDTO.fromDomain(e),
-    fromDocumentSnapshot: (doc) =>
-        PetShareInviteDTO.fromDocumentSnapshot(doc),
-  );
-});
-
-/// Parameters for [petShareInvitesQueryProvider].
-class PetShareInvitesQueryParams {
-  const PetShareInvitesQueryParams({this.family, this.clauses = const []});
-  final String? family;
-  final List<QueryClause> clauses;
 }
 
+/// Firestore collection path for pet share invites.
+@riverpod
+String petShareInviteCollectionPath(Ref ref) => 'petShareInvites';
+
+/// Repository provider for [PetShareInvite].
+@riverpod
+BaseFirestoreRepository<PetShareInvite> petShareInviteFirestoreRepository(
+        Ref ref) =>
+    BaseFirestoreRepository<PetShareInvite>(
+      collectionPath: ref.watch(petShareInviteCollectionPathProvider),
+      firestore: ref.watch(firestoreProvider),
+      user: ref.watch(userProvider).value!,
+      emptyEntity: PetShareInvite.empty(),
+      fromDomain: (e) => PetShareInviteDTO.fromDomain(e),
+      fromDocumentSnapshot: (doc) =>
+          PetShareInviteDTO.fromDocumentSnapshot(doc),
+    );
+
 /// Query provider for pet share invites.
-final petShareInvitesQueryProvider = AutoDisposeProvider.family<
-    Query<PetShareInvite>, PetShareInvitesQueryParams>((ref, params) {
+@riverpod
+Query<PetShareInvite> petShareInvitesQuery(
+  Ref ref, {
+  String? family,
+  List<QueryClause> clauses = const [],
+}) {
   final firestore = ref.watch(firestoreProvider);
   final collectionPath = ref.watch(petShareInviteCollectionPathProvider);
 
@@ -89,10 +85,10 @@ final petShareInvitesQueryProvider = AutoDisposeProvider.family<
     fromDomain: (e) => PetShareInviteDTO.fromDomain(e),
     fromDocumentSnapshot: (doc) =>
         PetShareInviteDTO.fromDocumentSnapshot(doc),
-    clauses: [...params.clauses, ...ref.watch(queryClausesProvider(params.family))],
+    clauses: [...clauses, ...ref.watch(queryClausesProvider(family))],
     stringAndField:
-        params.family != null ? ref.watch(searchNotifierProvider(params.family)) : null,
+        family != null ? ref.watch(searchNotifierProvider(family)) : null,
   );
 
   return queryHelper.query();
-});
+}


### PR DESCRIPTION
## Summary
- migrate `PetShareInviteDTO` to `freezed` for consistency
- rewrite pet share invite providers using riverpod annotations

## Testing
- `dart format -o none --set-exit-if-changed lib/pet_share/infrastructure/pet_share_invite_dto.dart lib/pet_share/shared/providers.dart` *(fails: command not found)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463d37a7e08328ba3e34a85b256081