### PR TITLE
Add LinkPet screen and router support

### DIFF
--- a/lib/pets/presentation/screens/create_or_import_pet_screen.dart
+++ b/lib/pets/presentation/screens/create_or_import_pet_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:petto/app/theme/app_theme_sizes.dart';
 import 'package:petto/onboarding/router.dart';
+import 'package:petto/pets/router.dart';
 
 class CreateOrImportPetScreen extends StatelessWidget {
   const CreateOrImportPetScreen({super.key});
@@ -38,7 +39,7 @@ class CreateOrImportPetScreen extends StatelessWidget {
                 ),
                 SizedBox(height: AppThemeSpacing.extraSmallH),
                 _PetCard(
-                  onTap: () {},
+                  onTap: () => const LinkPetRoute().push(context),
                   titleKey: 'addExistingPet',
                   descriptionKey: 'addExistingPetDescription',
                   colorScheme: colorScheme,

--- a/lib/pets/presentation/screens/link_pet_screen.dart
+++ b/lib/pets/presentation/screens/link_pet_screen.dart
@@ -1,0 +1,28 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:petto/app/theme/app_theme_sizes.dart';
+
+class LinkPetScreen extends StatelessWidget {
+  const LinkPetScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('addExistingPet'.tr()),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new_rounded),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: Center(
+        child: Padding(
+          padding: EdgeInsets.all(AppThemeSpacing.mediumH),
+          child: const Text('Link Pet Screen'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pets/router.dart
+++ b/lib/pets/router.dart
@@ -6,6 +6,7 @@ import 'package:petto/pets/presentation/screens/create_or_import_pet_screen.dart
 import 'package:petto/pets/presentation/screens/pet_details_screen.dart';
 import 'package:petto/pets/presentation/screens/pet_profile_screen.dart';
 import 'package:petto/pets/presentation/screens/pet_share_screen.dart';
+import 'package:petto/pets/presentation/screens/link_pet_screen.dart';
 import 'package:petto/core/files/application/app_file_view_model.dart';
 
 part 'router.g.dart';
@@ -16,6 +17,8 @@ part 'router.g.dart';
   routes: <TypedGoRoute<GoRouteData>>[
     // Step 1: choose how to add the pet
     TypedGoRoute<CreateOrImportPetRoute>(path: 'create-or-import'),
+    // Link existing pet
+    TypedGoRoute<LinkPetRoute>(path: 'link'),
     // Pet profile view
     TypedGoRoute<PetProfileRoute>(path: 'profile/:petId'),
     // Share pet view
@@ -37,6 +40,14 @@ class CreateOrImportPetRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const CreateOrImportPetScreen();
+}
+
+/// Route to link an existing pet to the current account.
+class LinkPetRoute extends GoRouteData {
+  const LinkPetRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => const LinkPetScreen();
 }
 
 /// Detail screen – shows one pet by id and optionally attached files.

--- a/lib/pets/router.g.dart
+++ b/lib/pets/router.g.dart
@@ -19,6 +19,10 @@ RouteBase get $petsRoute => GoRouteData.$route(
           factory: $CreateOrImportPetRouteExtension._fromState,
         ),
         GoRouteData.$route(
+          path: 'link',
+          factory: $LinkPetRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
           path: 'profile/:petId',
           factory: $PetProfileRouteExtension._fromState,
         ),
@@ -56,6 +60,23 @@ extension $CreateOrImportPetRouteExtension on CreateOrImportPetRoute {
 
   String get location => GoRouteData.$location(
         '/pets/create-or-import',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $LinkPetRouteExtension on LinkPetRoute {
+  static LinkPetRoute _fromState(GoRouterState state) => const LinkPetRoute();
+
+  String get location => GoRouteData.$location(
+        '/pets/link',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- add LinkPetScreen with a simple view
- register new LinkPetRoute in pets router
- enable navigation from create-or-import screen
- update generated router

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3ada648c8328b632fb618c4e09f2